### PR TITLE
Update Get-OneNoteTags.psm1

### DIFF
--- a/ScriptModules/Get-OneNoteTags.psm1
+++ b/ScriptModules/Get-OneNoteTags.psm1
@@ -11,17 +11,18 @@ function Get-OneNoteTags {
     $xml = Get-OneNotePageXML -Id $EnrichedPageObject.Id
 
     # check if there are any tags on the page
-    $tagNames = @()
-    if ($xml.TagDef.Length -gt 0) {
-        $countTags = $xml.TagDef.count
-        for ($i = 0; $i -lt $countTags; $i++) {
+    if ($null -ne $xml.TagDef) {                # This means that there are (at least 1) TagDef
+        $xmlTagArray = [array]$xml.TagDef       # Here we cast all to array so that the count works
+        $tagNames = @()
+        $countTags = $xmlTagArray.count
+        for ($i=0; $i -lt $countTags; $i++) {
             $tag = [PSCustomObject]@{
-                index          = $xml.TagDef[$i].index
-                type           = $xml.TagDef[$i].type
-                symbol         = $xml.TagDef[$i].symbol
-                fontColor      = $xml.TagDef[$i].fontcolor
-                highlightColor = $xml.TagDef[$i].highlightcolor
-                name           = $xml.TagDef[$i].name
+                index          = $xmlTagArray[$i].index
+                type           = $xmlTagArray[$i].type
+                symbol         = $xmlTagArray[$i].symbol
+                fontColor      = $xmlTagArray[$i].fontcolor
+                highlightColor = $xmlTagArray[$i].highlightcolor
+                name           = $xmlTagArray[$i].name
             }
             $tagNames += $tag
         }


### PR DESCRIPTION
First off, thanks for the great tool! I was looking for a quick way to extract all Tags (To Do's) in my OneNote pages. I have updated the section used to get Tags, as in some cases the XML read was returning either a System.Object[] (when more than 1 TagDef is retrieved) or a single XmlElement (when only one is retrieved). Because of this, the "count" method used for $countTags was failing for single-element XmlElement, and subsequently not all Tags in a Notebook/Page/Section were properly retrieved. The basic step of the change is to cast the xml.TagRef to an array before counting them. I tested the baseline on my OneNote and noticed that not all To Do's were captured... some debugging after, now seems to be OK. Cheers